### PR TITLE
Load Dummy Image over HTTPS

### DIFF
--- a/popup.php
+++ b/popup.php
@@ -139,7 +139,7 @@ $current_filename = substr($current_filename, (strrpos($current_filename, "/") +
                 preview.removeAttribute("style");
             }
         } else {
-            preview.setAttribute("src", "http://via.placeholder.com/150x150");
+            preview.setAttribute("src", "https://via.placeholder.com/150x150");
         }
     }
     function enableSubmitButton(file, submit)


### PR DESCRIPTION
This is to remove the warning on SSL enabled sites that occurs in some browsers that the page is insecure due to loading the image over an HTTP connection versus an HTTPS connection.