### PR TITLE
Change php echo  shorthand for full <?php echo to be more compatable

### DIFF
--- a/popup.php
+++ b/popup.php
@@ -87,7 +87,7 @@ $current_filename = substr($current_filename, (strrpos($current_filename, "/") +
 
 		<input type="file" name="userfile" id="userfile" onchange="imageHandle(event);" />
         <div>
-            <img src="<?= $current_fullpath ?>" width="150px" height="150px" style="object-fit: cover"/>
+            <img src="<?php echo $current_fullpath ?>" width="150px" height="150px" style="object-fit: cover"/>
             <img id="previewImage" src="http://via.placeholder.com/150x150" width="150px" height="150px"/>
         </div>
 
@@ -103,7 +103,7 @@ $current_filename = substr($current_filename, (strrpos($current_filename, "/") +
 
         <?php endif; ?>
 		<?php if ( apply_filters( 'emr_enable_replace_and_search', true ) ) : ?>
-		<label for="replace_type_2"><input <?= $s3pluginExist ? 'CHECKED' : '' ?> id="replace_type_2" type="radio" name="replace_type" value="replace_and_search"> <?php echo __("Replace the file, use new file name and update all links", "enable-media-replace"); ?></label>
+		<label for="replace_type_2"><input <?php echo $s3pluginExist ? 'CHECKED' : '' ?> id="replace_type_2" type="radio" name="replace_type" value="replace_and_search"> <?php echo __("Replace the file, use new file name and update all links", "enable-media-replace"); ?></label>
 		<p class="howto"><?php printf( __("Note: If you check this option, the name and type of the file you are about to upload will replace the old file. All links pointing to the current file (%s) will be updated to point to the new file name.", "enable-media-replace"), $current_filename ); ?></p>
 		<p class="howto"><?php echo __("Please note that if you upload a new image, only embeds/links of the original size image will be replaced in your posts.", "enable-media-replace"); ?></p>
 		<?php endif; ?>


### PR DESCRIPTION
Had a problem on our server where the `<?=` shorthand is disabled, leading to errors. Using the full `<?php echo` fixes the issues.