### PR TITLE
Remove wp-admin from admin_url() call

### DIFF
--- a/upload.php
+++ b/upload.php
@@ -383,7 +383,7 @@ if (is_uploaded_file($_FILES["userfile"]["tmp_name"])) {
 } else {
 	//TODO Better error handling when no file is selected.
 	//For now just go back to media management
-	$returnurl = admin_url("/wp-admin/upload.php");
+	$returnurl = admin_url("upload.php");
 }
 
 if (FORCE_SSL_ADMIN) {


### PR DESCRIPTION
Removes `wp-admin` from the call to `admin_url()`, fixes #20 