### PR TITLE
Don't boot the plugin if is not admin request.

### DIFF
--- a/enable-media-replace.php
+++ b/enable-media-replace.php
@@ -30,6 +30,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
+if ( ! is_admin() ) {
+	return;
+}
+
 if(!defined("S3_UPLOADS_AUTOENABLE")) {
     define('S3_UPLOADS_AUTOENABLE', true);
 }

--- a/enable-media-replace.php
+++ b/enable-media-replace.php
@@ -30,10 +30,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-if ( ! is_admin() ) {
-	return;
-}
-
 if(!defined("S3_UPLOADS_AUTOENABLE")) {
     define('S3_UPLOADS_AUTOENABLE', true);
 }
@@ -57,4 +53,4 @@ require_once('classes/emr-plugin.php');
 require_once('classes/externals.php');
 require_once('thumbnail_updater.php');
 
-$emr_plugin = EnableMediaReplacePlugin::get();
+add_action('admin_init', 'EnableMediaReplacePlugin::get');


### PR DESCRIPTION
### Description
We have been seeing recurring slow transaction times in our NewRelic traces that point to `enable-media-replace` and `wp_mkdir_p()`. We don't think it's actually `enable-media-replace` at all. It is presumably due to [S3-Uploads](https://github.com/humanmade/S3-Uploads) having to wait on responses from S3. From a brief code review, `enable-media-replace` does not need to load outside of `/wp-admin`, so we can skip the full boot-up when not in the admin and prevent the delay when it's not necessary.

### Example trace
![image](https://user-images.githubusercontent.com/68586/70671125-94505a00-1c40-11ea-98ef-85d184ff4355.png)
