### PR TITLE
Release version 3.3.11

### DIFF
--- a/classes/emr-plugin.php
+++ b/classes/emr-plugin.php
@@ -260,9 +260,14 @@ class EnableMediaReplacePlugin
 
   public function attachment_editor($form_fields, $post)
   {
-      $screen = get_current_screen();
-      if(! is_null($screen) && $screen->id == 'attachment') // hide on edit attachment screen.
-        return $form_fields;
+      $screen = null;
+      if (function_exists('get_current_screen'))
+      {
+        $screen = get_current_screen();
+
+        if(! is_null($screen) && $screen->id == 'attachment') // hide on edit attachment screen.
+          return $form_fields;
+      }
 
       $url = $this->getMediaReplaceURL($post->ID);
       $action = "media_replace";

--- a/enable-media-replace.php
+++ b/enable-media-replace.php
@@ -3,7 +3,7 @@
 Plugin Name: Enable Media Replace
 Plugin URI: https://wordpress.org/plugins/enable-media-replace/
 Description: Enable replacing media files by uploading a new file in the "Edit Media" section of the WordPress Media Library.
-Version: 3.3.10-DEV01
+Version: 3.3.11
 Author: ShortPixel
 Author URI: https://shortpixel.com
 Text Domain: enable-media-replace
@@ -25,7 +25,7 @@ http://www.gnu.org/licenses/gpl.html
  */
 
 namespace EnableMediaReplace;
-define('EMR_VERSION', '3.3.10-DEV01');
+define('EMR_VERSION', '3.3.11');
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.

--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@ Contributors: ShortPixel
 Donate link: https://www.paypal.me/resizeImage
 Tags: replace, attachment, media, files, replace image, replace jpg, change media, replace media, image, file
 Requires at least: 4.9.7
-Tested up to: 5.3
+Tested up to: 5.3.2
 Requires PHP: 5.6
-Stable tag: trunk
+Stable tag: 3.3.11
 
 Easily replace any attached image/file by simply uploading a new file in the Media Library edit view - a real time saver!
 
@@ -46,6 +46,16 @@ If you want more control over the format used to display the time, you can use t
 * [Regenerate Thumbnails Advanced](https://wordpress.org/plugins/regenerate-thumbnails-advanced/) - Fast, free and simple to use plugin to regenerate the thumbnails for your site after changing a theme (for example). Supported & maintained by [ShortPixel](https://ShortPixel.com)
 
 == Changelog ==
+
+= 3.3.11 =
+
+Release date: 10th March 2020
+* Fix the crashing of certain frontend builders when the plugin is active.
+
+= 3.3.10 =
+
+Release date: 23rd February 2020
+* Fix issue with JSON encoding which was interfering with Advanced Custom Fields and other plugins
 
 = 3.3.9 =
 


### PR DESCRIPTION
Hotfix - Prevent EMR from crashing when screen object is not found. This happens with frontend builders and what not