### PR TITLE
Fix $url param at getFormUrl

### DIFF
--- a/classes/uihelper.php
+++ b/classes/uihelper.php
@@ -46,7 +46,7 @@ class UIHelper
     //      'noheader' => true,
           'action' => $action,
           'attachment_id' => $attach_id,
-      ));
+      ), $url);
 
       if (isset($_REQUEST['SHORTPIXEL_DEBUG']))
       {


### PR DESCRIPTION
Tiny fix to return proper URL at `getFormUrl`. It causes some issues on WP setups with custom paths/directories. So better to pass `$url` as second param in `add_query_arg` like you guys do in `getSuccesRedirect` and other functions. I assume this is actually a bug as you do define `$url = admin_url('upload.php');`

Thanks.